### PR TITLE
Update equihash API usage.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@
 const async = require('async');
 const bedrock = require('bedrock');
 const crypto = require('crypto');
-const equihash = require('equihash')('khovratovich');
+const equihash = require('equihash');
 const jsonld = bedrock.jsonld;
 
 const api = {};
@@ -31,12 +31,18 @@ api.sign = (options, callback) => {
     }],
     sign: ['proof', (results, callback) => {
       const signed = bedrock.util.clone(options.doc);
+      // convert solution to 32 bit big endian buffer
+      const ab = new ArrayBuffer(results.proof.solution.length * 4);
+      const dv = new DataView(ab);
+      results.proof.solution.forEach((v, i) => {
+        dv.setUint32(i * 4, v);
+      });
       signed.signature = {
         type: 'EquihashSignature2017',
         equihashParameterN: results.proof.n,
         equihashParameterK: results.proof.k,
-        nonce: results.proof.nonce,
-        signatureValue: Buffer.from(results.proof.value).toString('base64')
+        nonce: results.proof.nonce.toString('base64'),
+        signatureValue: Buffer.from(ab).toString('base64')
       };
       callback(null, signed);
     }]
@@ -62,13 +68,22 @@ api.verify = function(document, callback) {
     verify: ['normalize', (results, callback) => {
       const hash =
         crypto.createHash('sha256').update(results.normalize, 'utf8').digest();
+      // convert 32 bit big endian buffer solution to array
+      const b = Buffer.from(signature.signatureValue, 'base64');
+      const dv = new DataView(b.buffer, b.byteOffset, b.byteLength);
+      // convert from 32 bit big endian buffer
+      const solution = new Array(b.length / 4);
+      for(let i = 0; i < solution.length; ++i) {
+        solution[i] = dv.getUint32(i * 4);
+      }
+
       const equihashOptions = {
         n: signature.equihashParameterN,
         k: signature.equihashParameterK,
-        nonce: signature.nonce,
-        value: Buffer.from(signature.signatureValue, 'base64')
+        nonce: Buffer.from(signature.nonce, 'base64'),
+        solution: solution
       };
-      callback(null, equihash.verify(hash, equihashOptions));
+      equihash.verify(hash, equihashOptions, callback);
     }]
   }, (err, results) => {
     if(err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,8 @@ api.sign = (options, callback) => {
         crypto.createHash('sha256').update(results.normalize, 'utf8').digest();
       const equihashOptions = {
         n: options.n,
-        k: options.k
+        k: options.k,
+        algorithm: 'khovratovich'
       };
       equihash.solve(hash, equihashOptions, callback);
     }],
@@ -38,11 +39,11 @@ api.sign = (options, callback) => {
         dv.setUint32(i * 4, v);
       });
       signed.signature = {
-        type: 'EquihashSignature2017',
+        type: 'EquihashProof2017',
         equihashParameterN: results.proof.n,
         equihashParameterK: results.proof.k,
         nonce: results.proof.nonce.toString('base64'),
-        signatureValue: Buffer.from(ab).toString('base64')
+        proofValue: Buffer.from(ab).toString('base64'),
       };
       callback(null, signed);
     }]
@@ -69,7 +70,7 @@ api.verify = function(document, callback) {
       const hash =
         crypto.createHash('sha256').update(results.normalize, 'utf8').digest();
       // convert 32 bit big endian buffer solution to array
-      const b = Buffer.from(signature.signatureValue, 'base64');
+      const b = Buffer.from(signature.proofValue, 'base64');
       const dv = new DataView(b.buffer, b.byteOffset, b.byteLength);
       // convert from 32 bit big endian buffer
       const solution = new Array(b.length / 4);

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,8 +13,14 @@ const api = {};
 // NOTE: only exported for tests
 module.exports = api;
 
-// FIXME: deal with docs that already have signatures
 api.sign = (options, callback) => {
+  // FIXME: deal with docs that already have signatures
+  // FIXME: compact before accessing 'signature' alias
+  if(options.doc.signature) {
+    return callback(
+      new TypeError('Signing a document with a signature not yet supported.'));
+  }
+
   async.auto({
     normalize: callback => jsonld.normalize(options.doc, {
       algorithm: 'URDNA2015',
@@ -56,6 +62,10 @@ api.sign = (options, callback) => {
 };
 
 api.verify = function(document, callback) {
+  // FIXME: compact before accessing 'signature' alias
+  if(!document.signature) {
+    return callback(new TypeError('Missing signature.'));
+  }
 
   const unsignedDocument = bedrock.util.clone(document);
   const signature = unsignedDocument.signature;
@@ -66,7 +76,16 @@ api.verify = function(document, callback) {
       algorithm: 'URDNA2015',
       format: 'application/nquads'
     }, callback),
-    verify: ['normalize', (results, callback) => {
+    validate: callback => {
+      if(!signature.proofValue) {
+        return callback(new TypeError('Missing proof value.'));
+      }
+      if(typeof signature.proofValue !== 'string') {
+        return callback(new TypeError('Proof value must be a string.'));
+      }
+      callback();
+    },
+    verify: ['validate', 'normalize', (results, callback) => {
       const hash =
         crypto.createHash('sha256').update(results.normalize, 'utf8').digest();
       // convert 32 bit big endian buffer solution to array

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://github.com/digitalbazaar/equihash-signature#readme",
   "dependencies": {
     "async": "^2.4.1",
-    "equihash": "github:digitalbazaar/equihash#master",
+    "equihash": "github:digitalbazaar/equihash#wip",
     "jsonld-signatures": "github:digitalbazaar/jsonld-signatures#multiSignature"
   },
   "peerDependencies": {


### PR DESCRIPTION
- Use buffers and base64 encoding for nonces.
- Equihash array of ints for solution, convert to/from big endian 32 bit base64
  for JSON-LD.